### PR TITLE
removed a repeated word from s3.xml

### DIFF
--- a/graphicstext/c03-gl1geom/s3.xml
+++ b/graphicstext/c03-gl1geom/s3.xml
@@ -609,7 +609,7 @@ when it is compiled.  To use the camera, you should call</p>
 
 <np>to set up the projection and viewing transform before drawing the scene.
 Calling this function replaces the usual code
-code for setting up the projection and viewing transformations. It leaves the
+for setting up the projection and viewing transformations. It leaves the
 matrix mode set to <i>GL_MODELVIEW</i>.</np>
 
 <p>The remaining functions in the API are used to configure the camera.  This would usually


### PR DESCRIPTION
code was repeated twice in the paragraph right after the cameraApply(); command in section 3.3.5.